### PR TITLE
Added matplotlib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+matplotlib
 scipy
 pandas>=0.14 


### PR DESCRIPTION
Noted that in a near-vanilla python install, all worked with installing pyuvvis except that matplotlib was missing.
